### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,24 +10,24 @@ HiFi	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin			    KEYWORD2
-configureTx		KEYWORD2
-enableTx			KEYWORD2
-onTxReady     KEYWORD2
-configureRx 	KEYWORD2
-enableRx  		KEYWORD2
-onRxReady 		KEYWORD2
-write			    KEYWORD2
-read		      KEYWORD2
+begin	KEYWORD2
+configureTx	KEYWORD2
+enableTx	KEYWORD2
+onTxReady	KEYWORD2
+configureRx	KEYWORD2
+enableRx	KEYWORD2
+onRxReady	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
 
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-HIFI_AUDIO_MODE_MONO_LEFT     LITERAL1
-HIFI_AUDIO_MODE_MONO_RIGHT    LITERAL1
-HIFI_AUDIO_MODE_STEREO        LITERAL1
+HIFI_AUDIO_MODE_MONO_LEFT	LITERAL1
+HIFI_AUDIO_MODE_MONO_RIGHT	LITERAL1
+HIFI_AUDIO_MODE_STEREO	LITERAL1
 
-HIFI_CLK_MODE_USE_EXT_CLKS    LITERAL1
-HIFI_CLK_MODE_USE_TK_RK_CLK   LITERAL1
+HIFI_CLK_MODE_USE_EXT_CLKS	LITERAL1
+HIFI_CLK_MODE_USE_TK_RK_CLK	LITERAL1
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords